### PR TITLE
Remove try blocks that make debugging harder

### DIFF
--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -117,35 +117,32 @@ async def async_query(async_query: reasoner_pydantic.AsyncQuery):
 
 
 async def async_query_task(async_query: reasoner_pydantic.AsyncQuery):
-    try:
-        async_query.message = await normalize_message(app, async_query.message)
-        session = requests.Session()
-        retries = Retry(
-            total=3,
-            backoff_factor=3,
-            status_forcelist=[429, 500, 502, 503, 504],
-            method_whitelist=[
-                "HEAD",
-                "GET",
-                "PUT",
-                "DELETE",
-                "OPTIONS",
-                "TRACE",
-                "POST",
-            ],
-        )
-        session.mount("http://", HTTPAdapter(max_retries=retries))
-        session.mount("https://", HTTPAdapter(max_retries=retries))
-        logger.info(f"sending callback to: {async_query.callback}")
+    async_query.message = await normalize_message(app, async_query.message)
+    session = requests.Session()
+    retries = Retry(
+        total=3,
+        backoff_factor=3,
+        status_forcelist=[429, 500, 502, 503, 504],
+        method_whitelist=[
+            "HEAD",
+            "GET",
+            "PUT",
+            "DELETE",
+            "OPTIONS",
+            "TRACE",
+            "POST",
+        ],
+    )
+    session.mount("http://", HTTPAdapter(max_retries=retries))
+    session.mount("https://", HTTPAdapter(max_retries=retries))
+    logger.info(f"sending callback to: {async_query.callback}")
 
-        post_response = session.post(
-            url=async_query.callback,
-            headers={"Content-Type": "application/json", "Accept": "application/json"},
-            data=async_query.json(),
-        )
-        logger.info(f"async_query post status code: {post_response.status_code}")
-    except BaseException as e:
-        logger.exception(e)
+    post_response = session.post(
+        url=async_query.callback,
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        data=async_query.json(),
+    )
+    logger.info(f"async_query post status code: {post_response.status_code}")
 
 
 @app.get(


### PR DESCRIPTION
These try blocks catch all the exceptions and report them to the logger, but I'm pretty sure that will happen anyway. By doing this, they get rid of the line-number information that would help debug what is causing the errors. Try blocks that catch exceptions and change the return value have been left untouched.

WIP: need to test this out and make sure this approach makes sense.