### PR TITLE
Uniquify semantic types returned from the database

### DIFF
--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -234,7 +234,7 @@ async def get_semantic_types_handler() -> SemanticTypes:
 
     # get the distinct list of Biolink model types in the correct format
     # https://github.com/TranslatorSRI/NodeNormalization/issues/29
-    ret_val = SemanticTypes(semantic_types={"types": types})
+    ret_val = SemanticTypes(semantic_types={"types": list(set(types))})
 
     # return the data to the caller
     return ret_val


### PR DESCRIPTION
The `/get_semantic_types` endpoint returns a list with duplicates. I'm not sure why this is the case -- I'm guessing a loader is malfunctioning -- but this can be easily fixed by uniquifying the list before returning it to the endpoint.

Closes #153.