### PR TITLE
Improve conflation documentation

### DIFF
--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -121,9 +121,10 @@ paths:
       - Interfaces
   /get_normalized_nodes:
     get:
-      description: 'Returns the equivalent identifiers and semantic types for the curie(s)
-        entered. You can read more about this endpoint in the
-        <a href="https://github.com/NCATSTranslator/NodeNormalization/blob/master/documentation/API.md#get_normalized_nodes">NodeNorm API documentation</a>. '
+      description: 'Returns the equivalent identifiers and semantic types for the CURIEs entered.
+        You can optionally <a href="https://github.com/NCATSTranslator/Babel/blob/master/docs/Conflation.md">conflate identifiers</a> if needed.
+        You can read more about this endpoint in the
+        <a href="https://github.com/NCATSTranslator/NodeNormalization/blob/master/documentation/API.md#get_normalized_nodes">NodeNorm API documentation</a>.'
       parameters:
       - in: query
         name: curie
@@ -192,8 +193,7 @@ paths:
                     information_content: 74.9
                 type: object
           description: Results
-      summary: Get the equivalent identifiers and semantic types for the curie(s)
-        entered.
+      summary: Get the equivalent identifiers and semantic types for the CURIEs entered.
       tags:
       - Interfaces
   /get_semantic_types:

--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -258,8 +258,11 @@ async def get_conflations() -> ConflationList:
 
 @app.get(
     "/get_normalized_nodes",
-    summary="Get the equivalent identifiers and semantic types for the curie(s) entered.",
-    description="Returns the equivalent identifiers and semantic types for the curie(s)",
+    summary="Get the equivalent identifiers and semantic types for the CURIEs entered.",
+    description="Returns the equivalent identifiers and semantic types for the CURIEs entered."
+                "You can optionally <a href=\"https://github.com/NCATSTranslator/Babel/blob/master/docs/Conflation.md\">conflate identifiers</a> if needed."
+                "You can read more about this endpoint in the "
+                "<a href=\"https://github.com/NCATSTranslator/NodeNormalization/blob/master/documentation/API.md#get_normalized_nodes\">NodeNorm API documentation</a>.",
 )
 async def get_normalized_node_handler(
     curie: List[str] = fastapi.Query(


### PR DESCRIPTION
This PR tries to improve the documentation for the NodeNorm API, in particular by adding a bit more detail on how conflation works and provides links to both NodeNorm and Babel documentation.