### PR TITLE
Load a particular version of Biolink Model as per BIOLINK_MODEL_TAG

### DIFF
--- a/node_normalizer/server.py
+++ b/node_normalizer/server.py
@@ -123,6 +123,11 @@ async def status() -> Dict:
         "status": "running",
         "babel_version": babel_version,
         "babel_version_url": babel_version_url,
+        "biolink_model": {
+            "tag": BIOLINK_MODEL_TAG,
+            "url": f"https://github.com/biolink/biolink-model/tree/{BIOLINK_MODEL_TAG}",
+            "download_url": BIOLINK_MODEL_URL,
+        },
         "databases": {
             "eq_id_to_id_db": {
                 "dbname": "id-id",


### PR DESCRIPTION
This PR adds an environmental variable called BIOLINK_MODEL_TAG. Note that this must be the name of a tag or branch on the Biolink Model repository, such as "master" or "v4.3.6". Closes #316.