### PR TITLE
Install make in data-loading Dockerfile

### DIFF
--- a/data-loading/Dockerfile
+++ b/data-loading/Dockerfile
@@ -8,7 +8,7 @@ ARG DATA=/data
 RUN apt-get update
 RUN apt-get -y upgrade
 RUN apt-get -y install wget
-RUN apt-get -y install git gcc
+RUN apt-get -y install git gcc make
 
 # Create nru user
 RUN mkdir -p ${ROOT}

--- a/node_normalizer/resources/openapi.yml
+++ b/node_normalizer/resources/openapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Node Normalization
-  version: 2.5.0
+  version: 2.5.1
   contact:
     email: bizon@renci.org
     name: Chris Bizon


### PR DESCRIPTION
The `data-loading/Dockerfile` (built by `.github/workflows/release-loading.yml`) fails because `make` isn't installed, but `librdb`'s `make install` step needs it. This PR adds `make` to the apt install line. Also increments the version number to `v2.5.1`.

## Testing
- `docker build` of `data-loading/Dockerfile` now succeeds end to end locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)